### PR TITLE
HTTP status fixes and websocket notification enrichment

### DIFF
--- a/apps/ex_auctions_manager/lib/ex_auctions_manager/endpoints/auction/v1/receiver.ex
+++ b/apps/ex_auctions_manager/lib/ex_auctions_manager/endpoints/auction/v1/receiver.ex
@@ -51,7 +51,7 @@ defmodule ExAuctionsManager.Auctions.V1.Receiver do
       {:error, %Ecto.Changeset{valid?: false, errors: errors}} ->
         reasons = errors |> Enum.map(fn {_, {reason, _}} -> reason end)
 
-        json_resp(conn, 500, %{reasons: reasons})
+        json_resp(conn, 422, %{reasons: reasons})
     end
   end
 

--- a/apps/ex_auctions_manager/lib/ex_auctions_manager/endpoints/bid/v1/receiver.ex
+++ b/apps/ex_auctions_manager/lib/ex_auctions_manager/endpoints/bid/v1/receiver.ex
@@ -55,7 +55,7 @@ defmodule ExAuctionsManager.Bids.V1.Receiver do
 
         json_resp(
           conn,
-          500,
+          422,
           %{auction_id: auction_id, bid_value: bid_value, bidder: bidder, reasons: reasons}
         )
     end

--- a/apps/ex_auctions_manager/lib/ex_auctions_manager/endpoints/bid/v1/receiver.ex
+++ b/apps/ex_auctions_manager/lib/ex_auctions_manager/endpoints/bid/v1/receiver.ex
@@ -45,7 +45,7 @@ defmodule ExAuctionsManager.Bids.V1.Receiver do
 
     case DB.create_bid(auction_id, bid_value, bidder) do
       {:ok, %Bid{auction_id: ^auction_id, bid_value: ^bid_value, bidder: ^bidder}} ->
-        WebsocketUtils.notify_bid(auction_id)
+        WebsocketUtils.notify_bid(auction_id, bid_value)
 
         json_resp(conn, 201, %{auction_id: auction_id, bid_value: bid_value, bidder: bidder})
 

--- a/apps/ex_auctions_manager/test/endpoints/auctions_endpoint_test.exs
+++ b/apps/ex_auctions_manager/test/endpoints/auctions_endpoint_test.exs
@@ -54,7 +54,7 @@ defmodule ExAuctionsManager.AuctionsEndpointTests do
           _opts = [ttl: {3600, :seconds}]
         )
 
-      {:ok, %Tesla.Env{status: 500, body: body}} =
+      {:ok, %Tesla.Env{status: 422, body: body}} =
         Tesla.post(
           Tesla.client([]),
           "http://localhost:10000/api/v1/auctions",

--- a/apps/ex_auctions_manager/test/endpoints/bids_endpoint_test.exs
+++ b/apps/ex_auctions_manager/test/endpoints/bids_endpoint_test.exs
@@ -97,7 +97,7 @@ defmodule ExAuctionsManager.BidsEndpointTests do
           _opts = [ttl: {3600, :seconds}]
         )
 
-      assert {:ok, %Tesla.Env{status: 500, body: body}} =
+      assert {:ok, %Tesla.Env{status: 422, body: body}} =
                Tesla.post(
                  Tesla.client([]),
                  "http://localhost:10000/api/v1/bids/",
@@ -135,7 +135,7 @@ defmodule ExAuctionsManager.BidsEndpointTests do
 
       :timer.sleep(1500)
 
-      assert {:ok, %Tesla.Env{status: 500, body: body}} =
+      assert {:ok, %Tesla.Env{status: 422, body: body}} =
                Tesla.post(
                  Tesla.client([]),
                  "http://localhost:10000/api/v1/bids/",

--- a/apps/ex_gate/lib/ex_gate/socket/socket_utils.ex
+++ b/apps/ex_gate/lib/ex_gate/socket/socket_utils.ex
@@ -3,7 +3,7 @@ defmodule ExGate.WebsocketUtils do
     "AUCTION::" <> to_string(auction_id)
   end
 
-  def notify_bid(auction_id) do
+  def notify_bid(auction_id, bid_value) do
     name =
       auction_id
       |> get_auction_pg_name()
@@ -15,7 +15,7 @@ defmodule ExGate.WebsocketUtils do
     |> Enum.each(fn pid ->
       send(
         pid,
-        %{notification_type: :bid, auction_id: auction_id}
+        %{notification_type: :bid, auction_id: auction_id, bid_value: bid_value}
         |> Jason.encode!()
       )
     end)


### PR DESCRIPTION
In case we cannot create auctions or bids, the endpoint return 422 UNPROCESSABLE ENTITY. Also, websocket notification is now delivering bid_value, too
